### PR TITLE
Add assertion-based debugging feature

### DIFF
--- a/.claude/skills/debug-run/SKILL.md
+++ b/.claude/skills/debug-run/SKILL.md
@@ -69,6 +69,20 @@ npx debug-run ./bin/Debug/net8.0/MyApp.dll \
   --pretty
 ```
 
+### With Assertions (Halt on Invariant Violations)
+
+```bash
+npx debug-run ./bin/Debug/net8.0/MyApp.dll \
+  -a vsdbg \
+  -b "src/Services/OrderService.cs:42" \
+  --assert "order.Total >= 0" \
+  --assert "order.Items.Count > 0" \
+  --assert "this._repository != null" \
+  --pretty
+```
+
+Assertions are checked at every breakpoint hit, trace step, and regular step. When an assertion fails, the debugger halts immediately with an `assertion_failed` event containing the failed expression, actual value, stack trace, and locals.
+
 ## Attach Mode (Debug Running Process)
 
 For long-running services like web APIs:
@@ -138,6 +152,7 @@ npx debug-run ./bin/Debug/net8.0/MyApp.dll \
 | `-a, --adapter <name>` | Debug adapter: `vsdbg` (recommended for .NET), `debugpy` (Python) |
 | `-b, --breakpoint <loc>` | Breakpoint location as `file:line` (can specify multiple) |
 | `-e, --eval <expr>` | Expression to evaluate at breakpoints (can specify multiple) |
+| `--assert <expr>` | Invariant expression; stops on first violation (can specify multiple) |
 | `-t, --timeout <time>` | Timeout duration: `30s`, `2m`, `5m` (default: 60s) |
 | `--pretty` | Pretty-print JSON output |
 | `--attach` | Attach to running process instead of launching |
@@ -174,6 +189,31 @@ debug-run outputs NDJSON events. Key event types:
     "evaluations": {
       "order.Total": { "value": "125.50" },
       "order.Items.Count": { "value": "3" }
+    }
+  }
+}
+```
+
+### assertion_failed
+
+```json
+{
+  "type": "assertion_failed",
+  "timestamp": "...",
+  "threadId": 1,
+  "assertion": "order.Total >= 0",
+  "actualValue": "-50",
+  "evaluationError": null,
+  "location": {
+    "file": "src/Services/OrderService.cs",
+    "line": 42,
+    "function": "ProcessOrder"
+  },
+  "stackTrace": [...],
+  "locals": {
+    "order": {
+      "type": "Order",
+      "value": {...}
     }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ export interface CliOptions {
   breakpoint: string[];
   logpoint: string[];
   eval: string[];
+  assert: string[];
   breakOnException?: string[];
   timeout?: string;
   captureLocals?: boolean;
@@ -78,6 +79,11 @@ export function createCli(): Command {
     .option(
       "-e, --eval <expr...>",
       "Expressions to evaluate when breakpoints are hit",
+      []
+    )
+    .option(
+      "--assert <expr...>",
+      "Invariant expressions that must remain truthy; stops on first violation",
       []
     )
     .option(
@@ -251,6 +257,7 @@ async function runDebugSession(options: CliOptions & { env?: string[] }): Promis
       logpoints: options.logpoint && options.logpoint.length > 0 ? options.logpoint : undefined,
       exceptionFilters: options.breakOnException,
       evaluations: options.eval.length > 0 ? options.eval : undefined,
+      assertions: options.assert.length > 0 ? options.assert : undefined,
       timeout,
       captureLocals: options.captureLocals,
       steps: options.steps,

--- a/src/output/events.ts
+++ b/src/output/events.ts
@@ -194,6 +194,18 @@ export interface ErrorEvent extends BaseEvent {
   details?: string;
 }
 
+// Assertion events
+export interface AssertionFailedEvent extends BaseEvent {
+  type: "assertion_failed";
+  threadId: number;
+  assertion: string;
+  actualValue: string;
+  evaluationError?: string;
+  location: SourceLocation;
+  stackTrace: StackFrameInfo[];
+  locals: Record<string, VariableValue>;
+}
+
 // Union type of all events
 export type DebugEvent =
   | SessionStartEvent
@@ -211,4 +223,5 @@ export type DebugEvent =
   | TraceStepEvent
   | TraceCompletedEvent
   | ProgramOutputEvent
-  | ErrorEvent;
+  | ErrorEvent
+  | AssertionFailedEvent;


### PR DESCRIPTION
## Summary
- Adds `--assert <expr>` CLI option for specifying invariant expressions that must remain truthy
- Emits `assertion_failed` event when an assertion evaluates to false or throws an error
- Assertions are checked at breakpoints, after each step, and during trace mode
- Session ends immediately upon first assertion failure, capturing full debug context

## Test plan
- [x] Verified assertion that passes (`order != null`) - session continues normally
- [x] Verified assertion that fails (`order.Total < 0`) - `assertion_failed` event emitted correctly
- [x] Verified assertions work in trace mode - checked at each trace step
- [x] Verified assertion failure during trace stops trace and emits correct event with location context

🤖 Generated with [Claude Code](https://claude.com/claude-code)